### PR TITLE
Add Travis CI support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,25 @@
+language: c
+env:
+  matrix:
+    - ARDUINO_SDK_VERSION=1.6.13
+    - ARDUINO_SDK_VERSION=1.8.4
+addons:
+  apt:
+    packages:
+      - cmake
+      - gcc-avr
+      - binutils-avr
+      - avr-libc
+      - avrdude
+before_install:
+  - wget "https://downloads.arduino.cc/arduino-$ARDUINO_SDK_VERSION-linux32.tar.xz" -O arduino-sdk.tar.xz
+  - mkdir arduino-sdk
+  - tar xf arduino-sdk.tar.xz -C arduino-sdk --strip-components 1
+  - export ARDUINO_SDK_PATH="$(pwd)/arduino-sdk"
+install:
+  - mkdir build
+  - rm -rf build/*
+  - cd build/
+script:
+  - cmake -D ARDUINO_SDK_PATH="$ARDUINO_SDK_PATH" ..
+  - make

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,8 @@
 =============
 Arduino CMake
 =============
+.. image:: https://travis-ci.org/NewNetWay/arduino-cmake.svg?branch=master
+    :target: https://travis-ci.org/NewNetWay/arduino-cmake
 
 Arduino is a great development platform, which is easy to use. It has everything a beginner should need. The *Arduino IDE* simplifies a lot of things for the standard user, but if you are a professional programmer the IDE can feel simplistic and restrictive.
 


### PR DESCRIPTION
This is a minimun CI script.

It generates the build system and compiles the examples available on the repo for Arduino SDK versions 1.6 and 1.8. This can be further extended by adding examples covering edge cases, making it a "teach by example" and a test case at the same time. 

I think it is a good idea to "document through examples". Besides the extensive README, the "show me the code" approach also works fine for most of the users.

Currently the build is failing because we can't generate them locally either.