### PR TITLE
Fixed explicit sketch files generation and updated the gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
-build
-
 ### CMake template
 CMakeCache.txt
 CMakeFiles
@@ -10,6 +8,79 @@ cmake_install.cmake
 install_manifest.txt
 compile_commands.json
 CTestTestfile.cmake
+
+### C++ template
+# Prerequisites
+*.d
+
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Fortran module files
+*.mod
+*.smod
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+
+# Executables
+*.exe
+*.out
+*.app
+
+### C template
+# Prerequisites
+
+# Object files
+*.ko
+*.elf
+
+# Linker output
+*.ilk
+*.map
+*.exp
+
+# Precompiled Headers
+
+# Libraries
+
+# Shared objects (inc. Windows DLLs)
+*.so.*
+
+# Executables
+*.i*86
+*.x86_64
+*.hex
+
+# Debug files
+*.dSYM/
+*.su
+*.idb
+*.pdb
+
+# Kernel Module Compile Results
+*.mod*
+*.cmd
+.tmp_versions/
+modules.order
+Module.symvers
+Mkfile.old
+dkms.conf
 
 ### JetBrains template
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and Webstorm
@@ -33,6 +104,9 @@ CTestTestfile.cmake
 .idea/**/gradle.xml
 .idea/**/libraries
 
+# CMake
+cmake-build-debug/
+
 # Mongo Explorer plugin:
 .idea/**/mongoSettings.xml
 
@@ -42,13 +116,16 @@ CTestTestfile.cmake
 ## Plugin-specific files:
 
 # IntelliJ
-/out/
+out/
 
 # mpeltonen/sbt-idea plugin
 .idea_modules/
 
 # JIRA plugin
 atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
 
 # Crashlytics plugin (for Android Studio and IntelliJ)
 com_crashlytics_export_strings.xml

--- a/cmake/Platform/Arduino.cmake
+++ b/cmake/Platform/Arduino.cmake
@@ -1815,18 +1815,21 @@ function(SETUP_ARDUINO_SKETCH TARGET_NAME SKETCH_PATH OUTPUT_VAR)
     if (EXISTS "${SKETCH_PATH}")
         set(SKETCH_CPP ${CMAKE_CURRENT_BINARY_DIR}/${TARGET_NAME}_${SKETCH_NAME}.cpp)
 
+        # Always set sketch path to the parent directory -
+        # Sketch files will be found later
+        string(REGEX REPLACE "[^\\/]+(.\\.((pde)|(ino)))" ""
+                SKETCH_PATH ${SKETCH_PATH})
+
         # Find all sketch files
         file(GLOB SKETCH_SOURCES ${SKETCH_PATH}/*.pde ${SKETCH_PATH}/*.ino)
         list(LENGTH SKETCH_SOURCES NUMBER_OF_SOURCES)
         if (NUMBER_OF_SOURCES LESS 0) # Sketch sources not found
             message(FATAL_ERROR "Could not find sketch
-            (${SKETCH_NAME}.pde or ${SKETCH_NAME}.ino) at ${SKETCH_PATH}!
-            Please specify the main sketch file path instead of directory.")
+            (${SKETCH_NAME}.pde or ${SKETCH_NAME}.ino) at ${SKETCH_PATH}!")
         endif ()
         list(SORT SKETCH_SOURCES)
         message(STATUS "SKETCH_SOURCES: ${SKETCH_SOURCES}")
 
-        #generate_cpp_from_sketch("" "${SKETCH_SOURCES}" "${SKETCH_CPP}")
         generate_sketch_cpp(${SKETCH_SOURCES} ${SKETCH_CPP})
 
         # Regenerate build system if sketch changes
@@ -2281,7 +2284,7 @@ function(get_arduino_flags COMPILE_FLAGS_VAR LINK_FLAGS_VAR BOARD_ID MANUAL)
         if (NOT MANUAL)
             set(COMPILE_FLAGS "${COMPILE_FLAGS} -I\"${${BOARD_CORE}.path}\" -I\"${ARDUINO_LIBRARIES_PATH}\"")
             if (${ARDUINO_PLATFORM_LIBRARIES_PATH})
-              set(COMPILE_FLAGS "${COMPILE_FLAGS} -I\"${ARDUINO_PLATFORM_LIBRARIES_PATH}\"")
+                set(COMPILE_FLAGS "${COMPILE_FLAGS} -I\"${ARDUINO_PLATFORM_LIBRARIES_PATH}\"")
             endif ()
         endif ()
         set(LINK_FLAGS "-mmcu=${${BOARD_ID}.build.mcu}")

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -42,6 +42,7 @@ GENERATE_ARDUINO_EXAMPLE(blink_example
 # Some installations have renamed the example directories
 if (EXISTS "${ARDUINO_SDK_PATH}/examples/01.Basics/Blink")
     set(BLINK_SKETCH "${ARDUINO_SDK_PATH}/examples/01.Basics/Blink")
+    set(BLINK_FILE_SKETCH "${ARDUINO_SDK_PATH}/examples/01.Basics/Blink/Blink.ino")
 else ()
     set(BLINK_SKETCH "${ARDUINO_SDK_PATH}/examples/1.Basics/Blink")
 endif ()
@@ -50,6 +51,10 @@ generate_arduino_firmware(blink_original
         SKETCH "${BLINK_SKETCH}"
         PORT /dev/ttyACM0
         SERIAL picocom @SERIAL_PORT@
+        BOARD uno)
+
+GENERATE_ARDUINO_FIRMWARE(blink_file_original
+        SKETCH "${BLINK_FILE_SKETCH}"
         BOARD uno)
 
 # Alternative: by variables


### PR DESCRIPTION
Fixed a **bug** where generating firmware for an explicit sketch file (including the `.ino` or `.pde` extension) would fail the build. 
**Solution** was to handle the files by their parent directory, marking them as the main sketch file when the directory is parsed.

Also updated the `.gitignore` file to ignore C and C++ files, resulting in a cleaner build environment.