### PR TITLE
Implemented register_hardware_platform_bva(...)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -918,6 +918,30 @@ This section will outlines some of the additional miscellaneous functions availa
   
   A good example of a *Hardware Platform* is in the Arduino SDK: ``${ARDUINO_SDK_PATH}/hardware/arduino/``
 
+* **register_hardware_platform_bva(BASE_PATH VENDOR_ID ARCHITECTURE_ID)**:
+
+        *BASE_PATH*         - Hardware platform path
+        *VENDOR_ID*         - The vendor id (e.g. arduino)
+        *ARCHITECTURE_ID*   - The architecture id (e.g. avr)
+
+ Registers a ``Hardware Platform`` path. See: `Arduino Platforms PRE 1.5`_ and `Arduino Platforms 1.5`_.
+
+ A Hardware Platform is a directory containing the following::
+
+        BASE_PATH/VENDOR_ID/ARCHITECTURE_ID/
+            |-- bootloaders/
+            |-- cores/
+            |-- variants/
+            |-- boards.txt
+            `-- programmers.txt
+  
+  This enables you to register new types of hardware platforms such as the
+  Sagnuino, without having to copy the files into your Arduino SDK.
+
+  The ``board.txt`` describes the target boards and bootloaders. While
+  ``programmers.txt`` the programmer defintions.
+  
+  A good example of a *Hardware Platform* is in the Arduino SDK: ``${ARDUINO_SDK_PATH}/hardware/arduino/avr``
 
 .. _Arduino Platforms PRE 1.5: http://code.google.com/p/arduino/wiki/Platforms
 .. _Arduino Platforms 1.5: http://code.google.com/p/arduino/wiki/Platforms1

--- a/cmake/Platform/Arduino.cmake
+++ b/cmake/Platform/Arduino.cmake
@@ -257,6 +257,36 @@
 #        ${ARDUINO_SDK_PATH}/hardware/arduino/
 #
 #=============================================================================#
+# register_hardware_platform_bva(BASE_PATH VENDOR_ID ARCHITECTURE_ID)
+#=============================================================================#
+#
+#        BASE_PATH         - Hardware platform path
+#        VENDOR_ID         - The vendor id (e.g. arduino)
+#        ARCHITECTURE_ID   - The architecture id (e.g. avr)
+#
+# Registers a Hardware Platform path.
+# See: http://code.google.com/p/arduino/wiki/Platforms
+#
+# This enables you to register new types of hardware platforms such as the
+# Sagnuino, without having to copy the files into your Arduino SDK.
+#
+# A Hardware Platform is a directory containing the following:
+#
+#        BASE_PATH/VENDOR_ID/ARCHITECTURE_ID/
+#            |-- bootloaders/
+#            |-- cores/
+#            |-- variants/
+#            |-- boards.txt
+#            `-- programmers.txt
+#            
+#  The boards.txt describes the target boards and bootloaders. While
+#  programmers.txt the programmer defintions.
+#
+#  A good example of a Hardware Platform is in the Arduino SDK:
+#
+#        ${ARDUINO_SDK_PATH}/hardware/arduino/avr
+#
+#=============================================================================#
 # Configuration Options
 #=============================================================================#
 #
@@ -733,12 +763,25 @@ endfunction()
 #=============================================================================#
 function(REGISTER_HARDWARE_PLATFORM PLATFORM_PATH)
     string(REGEX REPLACE "/$" "" PLATFORM_PATH ${PLATFORM_PATH})
-    GET_FILENAME_COMPONENT(PLATFORM ${PLATFORM_PATH} NAME)
+    GET_FILENAME_COMPONENT(VENDOR_ID ${PLATFORM_PATH} NAME)
+    GET_FILENAME_COMPONENT(BASE_PATH ${PLATFORM_PATH} PATH)
+    
+    # The legacy default behavior is to assume avr as architecture
+    register_hardware_platform_bva("${BASE_PATH}" "${VENDOR_ID}" "avr")
 
-    # platform path changed in versions 1.5 and greater
-    if (ARDUINO_SDK_VERSION VERSION_GREATER 1.0.5)
-        set(PLATFORM_PATH "${PLATFORM_PATH}/avr")
-    endif ()
+endfunction()
+
+#=============================================================================#
+# REGISTER_HARDWARE_PLATFORM_BVA
+# [PUBLIC/USER]
+# see documentation at top
+#=============================================================================#
+function(REGISTER_HARDWARE_PLATFORM_BVA BASE_PATH VENDOR_ID ARCHITECTURE_ID)
+    
+    set(PLATFORM_PATH "${BASE_PATH}/${VENDOR_ID}/${ARCHITECTURE_ID}")
+    
+    # Preserve original behavior...
+    set(PLATFORM "${VENDOR_ID}")
 
     if (PLATFORM)
         # Avoid defining a platform multiple times if it has already been defined before
@@ -811,6 +854,14 @@ function(REGISTER_HARDWARE_PLATFORM PLATFORM_PATH)
                         get_filename_component(core ${dir} NAME)
                         set(CORES ${CORES} ${core} CACHE INTERNAL "A list of registered cores")
                         set(${core}.path ${dir} CACHE INTERNAL "The path to the core ${core}")
+                        
+                        # See https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5-3rd-party-Hardware-specification#referencing-another-core-variant-or-tool
+                        # for an explanation why cores must also be available as <vendor_id>:<core_id>
+                        # and <vendor_id>:<architecture_id>:<core_id>
+                        set(CORES ${CORES} "${VENDOR_ID}:${core}" CACHE INTERNAL "A list of registered cores")
+                        set(${VENDOR_ID}:${core}.path ${dir} CACHE INTERNAL "The path to the core ${core}")
+                        set(CORES ${CORES} "${VENDOR_ID}:${ARCHITECTURE_ID}:${core}" CACHE INTERNAL "A list of registered cores")
+                        set(${VENDOR_ID}:${ARCHITECTURE_ID}:${core}.path ${dir} CACHE INTERNAL "The path to the core ${core}")
                     endif ()
                 endforeach ()
             endif ()
@@ -818,7 +869,6 @@ function(REGISTER_HARDWARE_PLATFORM PLATFORM_PATH)
     endif ()
 
 endfunction()
-
 
 #=============================================================================#
 #                         Internal Functions


### PR DESCRIPTION
The `register_hardware_platform(...)` function currently treats all cores as if they were associated with the same vendor and hardware (avr by default). 

To comply with the way other cores are supposed to be referenced when new platforms are registered (see [here](https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5-3rd-party-Hardware-specification#referencing-another-core-variant-or-tool)), an additional function `register_hardware_platform_bva(...)` (bva=base, vendor, architecture) was implemented and documented that allows to specify a `vendor_id` and an `architecture_id` as function parameters. The function stores core information in two additional CMake variables to allow e.g. referencing cores as `arduino:arduino` (`<vendor_id>:<core_id>`) instead of `arduino` only.