### PR TITLE
Adding Arduino 1.8.5 SDK path ("Arduino.app/Contents/Java")

### DIFF
--- a/cmake/ArduinoToolchain.cmake
+++ b/cmake/ArduinoToolchain.cmake
@@ -77,7 +77,7 @@ if ((NOT ARDUINO_SDK_PATH) AND (NOT DEFINED ENV{_ARDUINO_CMAKE_WORKAROUND_ARDUIN
 
     find_path(ARDUINO_SDK_PATH
             NAMES lib/version.txt
-            PATH_SUFFIXES share/arduino Arduino.app/Contents/Resources/Java/ ${ARDUINO_PATHS}
+            PATH_SUFFIXES share/arduino Arduino.app/Contents/Resources/Java/ Arduino.app/Contents/Java/ ${ARDUINO_PATHS}
             HINTS ${SDK_PATH_HINTS}
             DOC "Arduino SDK base directory")
 elseif ((NOT ARDUINO_SDK_PATH) AND (DEFINED ENV{_ARDUINO_CMAKE_WORKAROUND_ARDUINO_SDK_PATH}))


### PR DESCRIPTION
 - it appears that Arduino 1.8.5 on High Sierra had moved the SDK
   from inside the Resources folder one level up. With this change
   arduino-cmake finds ARDUINO_SDK_PATH automatically. But without
   it, throws an error.

```
~/sketches/arduino-cmake/example ❯ cmake ..
-- The C compiler identification is GNU 4.9.2
-- The CXX compiler identification is GNU 4.9.2
-- Arduino SDK version 1.8.5: /Applications/Arduino.app/Contents/Java
-- Check for working C compiler: /Applications/Arduino.app/Contents/Java/hardware/tools/avr/bin/avr-gcc
-- Check for working C compiler: /Applications/Arduino.app/Contents/Java/hardware/tools/avr/bin/avr-gcc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /Applications/Arduino.app/Contents/Java/hardware/tools/avr/bin/avr-g++
-- Check for working CXX compiler: /Applications/Arduino.app/Contents/Java/hardware/tools/avr/bin/avr-g++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
```