### PR TITLE
added asm compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ cmake_minimum_required(VERSION 2.8)
 #====================================================================#
 #  Setup Project                                                     #
 #====================================================================#
-project(ArduinoExample C CXX)
+project(ArduinoExample C CXX ASM)
 
 print_board_list()
 print_programmer_list()

--- a/cmake/Platform/Core/SourceFinder.cmake
+++ b/cmake/Platform/Core/SourceFinder.cmake
@@ -15,21 +15,22 @@ function(find_sources VAR_NAME LIB_PATH RECURSE)
     set(FILE_SEARCH_LIST
             ${LIB_PATH}/*.cpp
             ${LIB_PATH}/*.c
-            ${LIB_PATH}/*.s
-            ${LIB_PATH}/*.S
             ${LIB_PATH}/*.cc
             ${LIB_PATH}/*.cxx
             ${LIB_PATH}/*.h
             ${LIB_PATH}/*.hh
-            ${LIB_PATH}/*.hxx)
+            ${LIB_PATH}/*.hxx
+            ${LIB_PATH}/*.[sS]
+            )
 
     if (RECURSE)
-        file(GLOB_RECURSE LIB_FILES ${FILE_SEARCH_LIST})
+        file(GLOB_RECURSE SOURCE_FILES ${FILE_SEARCH_LIST})
     else ()
-        file(GLOB LIB_FILES ${FILE_SEARCH_LIST})
+        file(GLOB SOURCE_FILES ${FILE_SEARCH_LIST})
     endif ()
 
-    if (LIB_FILES)
-        set(${VAR_NAME} ${LIB_FILES} PARENT_SCOPE)
+    if (SOURCE_FILES)
+        set(${VAR_NAME} ${SOURCE_FILES} PARENT_SCOPE)
     endif ()
 endfunction()
+


### PR DESCRIPTION
- Added ASM language project(ArduinoExample C CXX ASM) and setup_asm_flags function. This is required for pulseIn function, e.g. Robot_Control library.
- Fixed *find_sources* to avoid double include of assembly files on case-insensitive systems (windows).