### PR TITLE
Add AppVeyor support (Windows CI)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,3 +12,6 @@ indent_size = 4
 continuation_indent_size = 8
 
 trim_trailing_whitespace = true
+
+[*.{md,rst}]
+trim_trailing_whitespace = false

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,5 +36,6 @@ install:
   - cd build/
 script:
   - cmake -D ARDUINO_SDK_PATH="$ARDUINO_SDK_PATH" ..
-  - cat CMakeFiles/CMakeOutput.log
   - make
+after_script:
+  - cat CMakeFiles/CMakeOutput.log

--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,10 @@
 =============
 Arduino CMake
 =============
-.. image:: https://travis-ci.org/arduino-cmake/arduino-cmake.svg?branch=master
+.. image:: https://img.shields.io/travis/arduino-cmake/arduino-cmake/master.svg?label=linux
     :target: https://travis-ci.org/arduino-cmake/arduino-cmake
+.. image:: https://img.shields.io/appveyor/ci/arduino-cmake/arduino-cmake/master.svg?label=windows
+    :target: https://ci.appveyor.com/project/arduino-cmake/arduino-cmake
 
 Arduino is a great development platform, which is easy to use. It has everything a beginner should need. The *Arduino IDE* simplifies a lot of things for the standard user, but if you are a professional programmer the IDE can feel simplistic and restrictive.
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,23 @@
+version: '{build}'
+image: Visual Studio 2017
+environment:
+  matrix:
+    - ARDUINO_SDK_VERSION: 1.6.13
+    - ARDUINO_SDK_VERSION: 1.8.5
+install:
+  - ps: choco install make unzip
+  - ps: $env:ARDUINO_SDK_FILE = "arduino-$env:ARDUINO_SDK_VERSION-windows.zip"
+  - ps: $env:ARDUINO_SDK_URI = "https://downloads.arduino.cc/$env:ARDUINO_SDK_FILE"
+  - ps: wget "$env:ARDUINO_SDK_URI" -O "$env:ARDUINO_SDK_FILE"
+  - ps: unzip "$env:ARDUINO_SDK_FILE" -d "arduino-sdk"
+  - ps: $env:ARDUINO_SDK_PATH = "$pwd\arduino-sdk\arduino-$env:ARDUINO_SDK_VERSION"
+  # FIXME: Windows path separators (\) need to be changed to "/" for cmake to properly handle it
+  - ps: $env:ARDUINO_SDK_PATH = ($env:ARDUINO_SDK_PATH -replace "\\","/")
+build_script:
+  - ps: mkdir build
+  - ps: cd build
+  - ps: echo "$env:ARDUINO_SDK_PATH"
+  - ps: cmake -G "Unix Makefiles" -D ARDUINO_SDK_PATH="$env:ARDUINO_SDK_PATH" ..
+  - cmd: make
+on_finish:
+  - ps: cat CMakeFiles/CMakeOutput.log


### PR DESCRIPTION
As the title states.

Finally I got some time to throw into this and make it work. The `appveyor.yml` file is specially useful if we ever rewrite the `README`, since it states the bare minim needed for the proyect to run on Windows.

The proyect still needs to be enabled on the appveyor platform.

Closes #11