### PR TITLE
Fixed ARDUINO define

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Change Log
 
-### Version 2.0.0 (Dec 13th 2017)
+# Version [2.0.1](https://github.com/arduino-cmake/arduino-cmake/compare/v2.0.0...v2.0.1) (Dec 19th 2017)
+
+### Bug fixes
+
+* fixed `-DARDUINO` define for Arduino SDK versions between 1.0.0 and 1.5.8. This bug caused to included `WProgram.h` instead of `Arduino.h` for aforementioned versions.
+
+# Version 2.0.0 (Dec 13th 2017)
 
 An epic version which integrates too many changes to be listed and recorded since the latest stable version, which was **1.0.0**. It has been released almost <u>4 years ago</u>!
 

--- a/cmake/Platform/Core/BoardFlags/FlagsSetter.cmake
+++ b/cmake/Platform/Core/BoardFlags/FlagsSetter.cmake
@@ -70,9 +70,7 @@ function(_get_normalized_sdk_version OUTPUT_VAR)
             # -DARDUINO format after 1.0.0 combines all 3 version parts together,
             # e.g. for 1.5.3 version -DARDUINO=153
             set(NORMALIZED_VERSION
-                    "${ARDUINO_SDK_VERSION_MAJOR}\
-            ${ARDUINO_SDK_VERSION_MINOR}\
-            ${ARDUINO_SDK_VERSION_PATCH}")
+                    "${ARDUINO_SDK_VERSION_MAJOR}${ARDUINO_SDK_VERSION_MINOR}${ARDUINO_SDK_VERSION_PATCH}")
         endif ()
     endif ()
 


### PR DESCRIPTION
`ARDUINO` define was not working properly between Arduino SDK versions 1.0.0 and 1.6.0.
This issue was caused by CMake line splitting, and new line was separated by multiple spaces, so in order to get correct define e.g. 
```
-DARDUINO=105
```
it became 
```
-DARDUINO="1          0            5"
```

See #35 for more info.

### OR ...
Maybe show fatal error, if Arduino SKD is less than 1.6.0 ?