### PR TITLE
Allow ommitting mcu

### DIFF
--- a/cmake/Platform/Core/BoardFlags/CompilerFlagsSetter.cmake
+++ b/cmake/Platform/Core/BoardFlags/CompilerFlagsSetter.cmake
@@ -3,7 +3,11 @@ function(set_board_compiler_flags COMPILER_FLAGS NORMALIZED_SDK_VERSION BOARD_ID
 
     _get_board_property(${BOARD_ID} build.f_cpu FCPU)
     _get_board_property(${BOARD_ID} build.mcu MCU)
-    set(COMPILE_FLAGS "-DF_CPU=${FCPU} -DARDUINO=${NORMALIZED_SDK_VERSION} -mmcu=${MCU}")
+    set(COMPILE_FLAGS "-DF_CPU=${FCPU} -DARDUINO=${NORMALIZED_SDK_VERSION}")
+    
+    if(NOT "${MCU}" STREQUAL "")
+       set(COMPILE_FLAGS "${COMPILE_FLAGS} -mmcu=${MCU}")
+    endif()
 
     _try_get_board_property(${BOARD_ID} build.vid VID)
     _try_get_board_property(${BOARD_ID} build.pid PID)

--- a/cmake/Platform/Core/BoardFlags/LinkerFlagsSetter.cmake
+++ b/cmake/Platform/Core/BoardFlags/LinkerFlagsSetter.cmake
@@ -2,7 +2,9 @@
 function(set_board_linker_flags LINKER_FLAGS BOARD_ID IS_MANUAL)
 
     _get_board_property(${BOARD_ID} build.mcu MCU)
-    set(LINK_FLAGS "-mmcu=${MCU}")
+    if(NOT "${MCU}" STREQUAL "")
+       set(LINK_FLAGS "-mmcu=${MCU}")
+    endif()
     set(${LINKER_FLAGS} "${LINK_FLAGS}" PARENT_SCOPE)
 
 endfunction()


### PR DESCRIPTION
This PR enables simulated builds of firmware in an x86 environment, e.g. for regression testing.
gcc for x86 cannot deal with `-mmcu=...` definitions. Thus we only set them, if the respective board property is defined.