### PR TITLE
Enable build of shared libraries for x86 firmware simulations

### DIFF
--- a/cmake/Platform/Core/Libraries/ArduinoLibraryFactory.cmake
+++ b/cmake/Platform/Core/Libraries/ArduinoLibraryFactory.cmake
@@ -59,8 +59,11 @@ function(make_arduino_library VAR_NAME BOARD_ID LIB_PATH COMPILE_FLAGS LINK_FLAG
             if (LIB_TARGETS)
                 list(REMOVE_ITEM LIB_TARGETS ${TARGET_LIB_NAME})
             endif ()
-
-            target_link_libraries(${TARGET_LIB_NAME} ${BOARD_ID}_CORE ${LIB_TARGETS})
+            
+            if(NOT ARDUINO_CMAKE_GENERATE_SHARED_LIBRARIES)
+                target_link_libraries(${TARGET_LIB_NAME} ${BOARD_ID}_CORE ${LIB_TARGETS})
+            endif()
+            
             list(APPEND LIB_TARGETS ${TARGET_LIB_NAME})
 
         endif ()

--- a/cmake/Platform/Core/Targets/ArduinoFirmwareTargetCreator.cmake
+++ b/cmake/Platform/Core/Targets/ArduinoFirmwareTargetCreator.cmake
@@ -20,6 +20,11 @@ function(create_arduino_firmware_target TARGET_NAME BOARD_ID ALL_SRCS ALL_LIBS
 
     string(STRIP "${ALL_SRCS}" ALL_SRCS)
     add_executable(${TARGET_NAME} "${ALL_SRCS}")
+    if(ARDUINO_CMAKE_GENERATE_SHARED_LIBRARIES)
+        add_library(${TARGET_NAME} SHARED "${ALL_SRCS}")
+    else()
+        add_executable(${TARGET_NAME} "${ALL_SRCS}")
+    endif()
     set_target_properties(${TARGET_NAME} PROPERTIES SUFFIX ".elf")
 
     set_board_flags(ARDUINO_COMPILE_FLAGS ARDUINO_LINK_FLAGS ${BOARD_ID} ${MANUAL})
@@ -27,11 +32,25 @@ function(create_arduino_firmware_target TARGET_NAME BOARD_ID ALL_SRCS ALL_LIBS
     set_target_properties(${TARGET_NAME} PROPERTIES
             COMPILE_FLAGS "${ARDUINO_COMPILE_FLAGS} ${COMPILE_FLAGS}"
             LINK_FLAGS "${ARDUINO_LINK_FLAGS} ${LINK_FLAGS}")
-    target_link_libraries(${TARGET_NAME} ${ALL_LIBS} "-lc -lm")
 
+    if(ARDUINO_CMAKE_GENERATE_SHARED_LIBRARIES)
+      # When building a shared library we must make sure that
+      # all symbols from the intermediate static libraries end up in the
+      # static library
+      #
+      target_link_libraries(${TARGET_NAME} PUBLIC "-Wl,--whole-archive" ${ALL_LIBS} "-Wl,--no-whole-archive")
+    else()
+      target_link_libraries(${TARGET_NAME} ${ALL_LIBS} "-lc -lm")
+    endif()
+    
     if (NOT EXECUTABLE_OUTPUT_PATH)
         set(EXECUTABLE_OUTPUT_PATH ${CMAKE_CURRENT_BINARY_DIR})
     endif ()
+    
+    if(ARDUINO_CMAKE_ONLY_ELF)
+       return()
+    endif()
+    
     set(TARGET_PATH ${EXECUTABLE_OUTPUT_PATH}/${TARGET_NAME})
     add_custom_command(TARGET ${TARGET_NAME} POST_BUILD
             COMMAND ${CMAKE_OBJCOPY}

--- a/cmake/Platform/Initialization/SetupCompilerSettings.cmake
+++ b/cmake/Platform/Initialization/SetupCompilerSettings.cmake
@@ -54,7 +54,9 @@ endfunction()
 # Setups some basic flags for the gcc linker to use when linking executables.
 #=============================================================================#
 function(setup_exe_linker_flags)
-    set(ARDUINO_LINKER_FLAGS "-Wl,--gc-sections -lm")
+    if (NOT DEFINED ARDUINO_LINKER_FLAGS)
+        set(ARDUINO_LINKER_FLAGS "-Wl,--gc-sections -lm")
+    endif()
     set(CMAKE_EXE_LINKER_FLAGS "${ARDUINO_LINKER_FLAGS}" CACHE STRING "")
     set(CMAKE_EXE_LINKER_FLAGS_DEBUG "${ARDUINO_LINKER_FLAGS}" CACHE STRING "")
     set(CMAKE_EXE_LINKER_FLAGS_MINSIZEREL "${ARDUINO_LINKER_FLAGS}" CACHE STRING "")


### PR DESCRIPTION
For a [python wrapped firmware simulator](https://github.com/noseglasses/Kaleidoscope-Python) of the [Kaleidoscope keyboard firmware](https://github.com/keyboardio/Kaleidoscope) I need to be able to compile a virtual firmware for a x86 target as a shared library. This shared library is actually a python module.

This PR adds modification that are based on the variable `ARDUINO_CMAKE_GENERATE_SHARED_LIBRARIES` to be defined `TRUE`. It introduces another flag `ARDUINO_CMAKE_ONLY_ELF` that prevents the generation of platform specific targets that are only required for non-virtual firmware builds.