### PR TITLE
Conditionall getting properties to enable x86 builds

### DIFF
--- a/cmake/Platform/Core/BoardFlags/CompilerFlagsSetter.cmake
+++ b/cmake/Platform/Core/BoardFlags/CompilerFlagsSetter.cmake
@@ -1,13 +1,17 @@
 # ToDo: Comment
 function(set_board_compiler_flags COMPILER_FLAGS NORMALIZED_SDK_VERSION BOARD_ID IS_MANUAL)
 
-    _get_board_property(${BOARD_ID} build.f_cpu FCPU)
-    _get_board_property(${BOARD_ID} build.mcu MCU)
-    set(COMPILE_FLAGS "-DF_CPU=${FCPU} -DARDUINO=${NORMALIZED_SDK_VERSION}")
+    _try_get_board_property(${BOARD_ID} build.f_cpu FCPU)
+    if(NOT "${FCPU}" STREQUAL "")
+       set(COMPILE_FLAGS "-DF_CPU=${FCPU}")
+    endif()
     
+    _try_get_board_property(${BOARD_ID} build.mcu MCU)    
     if(NOT "${MCU}" STREQUAL "")
        set(COMPILE_FLAGS "${COMPILE_FLAGS} -mmcu=${MCU}")
     endif()
+    
+    set(COMPILE_FLAGS "${COMPILE_FLAGS} -DARDUINO=${NORMALIZED_SDK_VERSION}")
 
     _try_get_board_property(${BOARD_ID} build.vid VID)
     _try_get_board_property(${BOARD_ID} build.pid PID)

--- a/cmake/Platform/Core/BoardFlags/LinkerFlagsSetter.cmake
+++ b/cmake/Platform/Core/BoardFlags/LinkerFlagsSetter.cmake
@@ -1,7 +1,7 @@
 # ToDo: Comment
 function(set_board_linker_flags LINKER_FLAGS BOARD_ID IS_MANUAL)
 
-    _get_board_property(${BOARD_ID} build.mcu MCU)
+    _try_get_board_property(${BOARD_ID} build.mcu MCU)
     if(NOT "${MCU}" STREQUAL "")
        set(LINK_FLAGS "-mmcu=${MCU}")
     endif()

--- a/cmake/Platform/Core/Targets/ArduinoBootloaderArgumentsBuilder.cmake
+++ b/cmake/Platform/Core/Targets/ArduinoBootloaderArgumentsBuilder.cmake
@@ -18,24 +18,36 @@ function(build_arduino_bootloader_arguments BOARD_ID TARGET_NAME PORT AVRDUDE_FL
     if (NOT AVRDUDE_FLAGS)
         set(AVRDUDE_FLAGS ${ARDUINO_AVRDUDE_FLAGS})
     endif ()
-    _get_board_property(${BOARD_ID} build.mcu MCU)
+    
+    _try_get_board_property(${BOARD_ID} build.mcu MCU)
+    if(NOT "${MCU}" STREQUAL "")
+       list(APPEND AVRDUDE_ARGS
+            "-p${MCU}"        # MCU Type
+            )
+    endif()
+    
     list(APPEND AVRDUDE_ARGS
             "-C${ARDUINO_AVRDUDE_CONFIG_PATH}"  # avrdude config
-            "-p${MCU}"        # MCU Type
             )
 
     # Programmer
-    _get_board_property(${BOARD_ID} upload.protocol UPLOAD_PROTOCOL)
-    if (${UPLOAD_PROTOCOL} STREQUAL "stk500")
-        list(APPEND AVRDUDE_ARGS "-cstk500v1")
-    else ()
-        list(APPEND AVRDUDE_ARGS "-c${UPLOAD_PROTOCOL}")
-    endif ()
+    _try_get_board_property(${BOARD_ID} upload.protocol UPLOAD_PROTOCOL)
+    if(NOT "${UPLOAD_PROTOCOL}" STREQUAL "")
+      if (${UPLOAD_PROTOCOL} STREQUAL "stk500")
+         list(APPEND AVRDUDE_ARGS "-cstk500v1")
+      else ()
+         list(APPEND AVRDUDE_ARGS "-c${UPLOAD_PROTOCOL}")
+      endif ()
+    endif()
 
-
-    _get_board_property(${BOARD_ID} upload.speed UPLOAD_SPEED)
-    list(APPEND AVRDUDE_ARGS
+    _try_get_board_property(${BOARD_ID} upload.speed UPLOAD_SPEED)
+    if(NOT "${UPLOAD_SPEED}" STREQUAL "")
+        list(APPEND AVRDUDE_ARGS
             "-b${UPLOAD_SPEED}"     # Baud rate
+            )
+    endif()
+    
+    list(APPEND AVRDUDE_ARGS
             "-P${PORT}"             # Serial port
             "-D"                    # Dont erase
             )


### PR DESCRIPTION
In version 2.0 of arduino-cmake there are still some properties searched for that are not available on virtual builds for the x86 architecture. To enable such builds without errors of the CMake build system, I replaced board property retreivals with try-versions. Only it the respective variables are available, they are actually used.