### PR TITLE
Enabled to skip Arduino detection for vitual builds

### DIFF
--- a/cmake/Platform/Initialization/DetectVersion.cmake
+++ b/cmake/Platform/Initialization/DetectVersion.cmake
@@ -8,6 +8,14 @@
 #    ${OUTPUT_VAR_NAME}_PATCH   -> the patch version
 #
 #=============================================================================#
+
+# Enable skipping detection for builds that do not require 
+# Arduino. This mainly concerns virtual builds.
+#
+if(ARDUINO_CMAKE_SKIP_DETECT_VERSION)
+   return()
+endif()
+
 find_file(ARDUINO_VERSION_PATH
         NAMES lib/version.txt
         PATHS ${ARDUINO_SDK_PATH}

--- a/cmake/Platform/Initialization/TestSetup.cmake
+++ b/cmake/Platform/Initialization/TestSetup.cmake
@@ -1,3 +1,7 @@
+if(ARDUINO_CMAKE_SKIP_TEST_SETUP)
+   return()
+endif()
+
 # Ensure that all required paths are found
 VALIDATE_VARIABLES_NOT_EMPTY(VARS
         ARDUINO_PLATFORMS


### PR DESCRIPTION
To enable for builds that do not rely on any arduino stuff (virtual builds for x86) I added flags that enable early exit from some test files.