### PR TITLE
Removing duplicate entries in link libraries list

### DIFF
--- a/cmake/Platform/Core/Targets/ArduinoFirmwareTargetCreator.cmake
+++ b/cmake/Platform/Core/Targets/ArduinoFirmwareTargetCreator.cmake
@@ -31,6 +31,8 @@ function(create_arduino_firmware_target TARGET_NAME BOARD_ID ALL_SRCS ALL_LIBS
     set_target_properties(${TARGET_NAME} PROPERTIES
             COMPILE_FLAGS "${ARDUINO_COMPILE_FLAGS} ${COMPILE_FLAGS}"
             LINK_FLAGS "${ARDUINO_LINK_FLAGS} ${LINK_FLAGS}")
+            
+    list(REMOVE_DUPLICATES ALL_LIBS)
 
     if(ARDUINO_CMAKE_GENERATE_SHARED_LIBRARIES)
       # When building a shared library we must make sure that


### PR DESCRIPTION
Under specific circumstances there end up duplicate entries in ALL_LIBS that lead to multiply defined symbol errors during linking. This PR fixes this by removing those duplicate entries before generating the actual linker command line.