### PR TITLE
Replaced use of WIN32, APPLE, UNIX

### DIFF
--- a/cmake/ArduinoToolchain.cmake
+++ b/cmake/ArduinoToolchain.cmake
@@ -25,16 +25,16 @@ endif ()
 #=============================================================================#
 #                         System Paths                                        #
 #=============================================================================#
-if (UNIX)
+if (CMAKE_HOST_UNIX)
     include(Platform/UnixPaths)
-    if (APPLE)
+    if (CMAKE_HOST_APPLE)
         list(APPEND CMAKE_SYSTEM_PREFIX_PATH ~/Applications
                 /Applications
                 /Developer/Applications
                 /sw        # Fink
                 /opt/local) # MacPorts
     endif ()
-elseif (WIN32)
+elseif (CMAKE_HOST_WIN32)
     include(Platform/WindowsPaths)
 endif ()
 
@@ -57,13 +57,13 @@ if ((NOT ARDUINO_SDK_PATH) AND (NOT DEFINED ENV{_ARDUINO_CMAKE_WORKAROUND_ARDUIN
         list(APPEND ARDUINO_PATHS arduino-00${VERSION})
     endforeach ()
 
-    if (UNIX)
+    if (CMAKE_HOST_UNIX)
         file(GLOB SDK_PATH_HINTS
                 /usr/share/arduino*
                 /opt/local/arduino*
                 /opt/arduino*
                 /usr/local/share/arduino*)
-    elseif (WIN32)
+    elseif (CMAKE_HOST_WIN32)
         set(SDK_PATH_HINTS
                 "C:\\Program Files\\Arduino"
                 "C:\\Program Files (x86)\\Arduino")


### PR DESCRIPTION
I am working on a project that calls functions from Arduino-CMake after it calls `project(...)` and I just generated another PR that relies on platform checks and thereby stumbled upon a problem with variables `WIN32`, `UNIX` and `APPLE` becoming strangely undefined (CMake 3.5.1) after a certain point of CMake's execution.

Luckily, the problem was easy to track down using 
```
variable_watch(UNIX)
```

The reason is the following:  Arduino-CMake uses cross compiling. Because of this, the aforementioned variables are internally deleted by CMake during calls to
project(...) and they remain undefined later on. Any code that relies on these variables beyond a call to `project(...)` is likely to fail. The idea is that when cross compiling e.g. on GNU/Linux for Windows, after all call to `project(...)`, `WIN32` becomes `TRUE` and `UNIX` becomes undefined (i.e. implicitly FALSE). So those variables that are commonly used to detect the host platform are now used to inform about the target platform. In our case, the target platform avr does not have an assigned variable, leaving `WIN32`, `UNIX` and `APPLE` undefined after a call to `project(...)`.

Currently this is not a general problem with Arduino-CMake as those variables seem only to be used in code that runs before the invalidation. But if used in other places of Arduino-CMake that might be called after `project(...)` (like I did with my other PR) the resulting code is going to fail.

As we want to check the host platform, we should do this with the `CMAKE_HOST_*` family of variables. Those are defined throughout the whole execution of CMake. I replaced `WIN32`, `UNIX` and `APPLE` in existing code where I found them.

Even though Arduino-CMake currently passes its tests, as the above mentioned variables are used only before `project(...)` is called, I regard this PR important as new developers tend to look at existing code and copy snippets.

It is also important to use `CMAKE_HOST_*` in any newly written Arduino-CMake code to check the host platform.