### PR TITLE
Fixed properties that contain escaped strings for windows builds

### DIFF
--- a/cmake/Platform/Core/BoardFlags/CompilerFlagsSetter.cmake
+++ b/cmake/Platform/Core/BoardFlags/CompilerFlagsSetter.cmake
@@ -1,19 +1,37 @@
-# ToDo: Comment
-
+#=============================================================================#
+# _sanitize_quotes
+# [PRIVATE/INTERNAL]
+#
+# _sanitize_quotes(CMD_LINE_VARIABLE)
+#
+#       CMD_LINE_VARIABLE - Variable holding a shell command line 
+#                           or command line flag(s) that potentially 
+#                           require(s) quotes to be fixed.
+#
+# Replaces Unix-style quotes with Windows-style quotes.
+# '-DSOME_MACRO="foo"' would become "-DSOME_MACRO=\"foo\"".
+#
+#=============================================================================#
 function(_sanitize_quotes
-   cmd_line_var_
+   CMD_LINE_VARIABLE
 )
-   # Fix command line variables defined for Unix-Like systems.
-   # '-DSOME_MACRO="foo"' would become "-DSOME_MACRO=\"foo\""
-   # Note: Double double-quotes are preserved.
-   #
    if(CMAKE_HOST_WIN32)
-      string(REPLACE "\"" "\\\"" output "${${cmd_line_var_}}")
+   
+      # Important: The order of the statements below does matter!
+   
+      # First replace all occurences of " with \"
+      #
+      string(REPLACE "\"" "\\\"" output "${${CMD_LINE_VARIABLE}}")
+      
+      # Then replace all ' with "
+      #
       string(REPLACE "'" "\"" output "${output}")
-      set(${cmd_line_var_} "${output}" PARENT_SCOPE)
+      
+      set(${CMD_LINE_VARIABLE} "${output}" PARENT_SCOPE)
    endif()
 endfunction()
 
+# ToDo: Comment
 function(set_board_compiler_flags COMPILER_FLAGS NORMALIZED_SDK_VERSION BOARD_ID IS_MANUAL)
 
     _try_get_board_property(${BOARD_ID} build.f_cpu FCPU)

--- a/cmake/Platform/Core/BoardFlags/CompilerFlagsSetter.cmake
+++ b/cmake/Platform/Core/BoardFlags/CompilerFlagsSetter.cmake
@@ -1,4 +1,19 @@
 # ToDo: Comment
+
+function(_sanitize_quotes
+   cmd_line_var_
+)
+   # Fix command line variables defined for Unix-Like systems.
+   # '-DSOME_MACRO="foo"' would become "-DSOME_MACRO=\"foo\""
+   # Note: Double double-quotes are preserved.
+   #
+   if(CMAKE_HOST_WIN32)
+      string(REPLACE "\"" "\\\"" output "${${cmd_line_var_}}")
+      string(REPLACE "'" "\"" output "${output}")
+      set(${cmd_line_var_} "${output}" PARENT_SCOPE)
+   endif()
+endfunction()
+
 function(set_board_compiler_flags COMPILER_FLAGS NORMALIZED_SDK_VERSION BOARD_ID IS_MANUAL)
 
     _try_get_board_property(${BOARD_ID} build.f_cpu FCPU)
@@ -25,12 +40,14 @@ function(set_board_compiler_flags COMPILER_FLAGS NORMALIZED_SDK_VERSION BOARD_ID
     _try_get_board_property(${BOARD_ID} build.extra_flags EXTRA_FLAGS)
 
     if(NOT "${EXTRA_FLAGS}" STREQUAL "")
-        set(COMPILE_FLAGS "${COMPILE_FLAGS} ${EXTRA_FLAGS}")
+       _sanitize_quotes(EXTRA_FLAGS)
+       set(COMPILE_FLAGS "${COMPILE_FLAGS} ${EXTRA_FLAGS}")
     endif()
     
     _try_get_board_property(${BOARD_ID} build.usb_flags USB_FLAGS)
     if(NOT "${USB_FLAGS}" STREQUAL "")
-        set(COMPILE_FLAGS "${COMPILE_FLAGS} ${USB_FLAGS}")
+       _sanitize_quotes(USB_FLAGS)
+       set(COMPILE_FLAGS "${COMPILE_FLAGS} ${USB_FLAGS}")
     endif()
 
     if (NOT IS_MANUAL)


### PR DESCRIPTION
Some properties define in Arduino build system specification files are used as compiler command line arguments.

Arguments that are specified for Unix-like systems, e.g.
```
'-DLITERAL_STRING="the_string"'
```
cause compiler errors on Windows. These must be replaced to become
```
"-DLITERAL_STRING=\"the_string\""
```
on Windows.

This PR adds the necessary replacement to extra_flags and usb_flags.