### PR TITLE
Portable case sensitive path existence check

### DIFF
--- a/cmake/Platform/Core/LibraryFinder.cmake
+++ b/cmake/Platform/Core/LibraryFinder.cmake
@@ -29,6 +29,9 @@
 #
 #=============================================================================#
 function(find_arduino_libraries VAR_NAME SRCS ARDLIBS)
+
+    include(CheckPathExistsCaseSensitive)
+    
     set(ARDUINO_LIBS)
 
     if (ARDLIBS) # Libraries are known in advance, just find their absoltue paths
@@ -42,23 +45,31 @@ function(find_arduino_libraries VAR_NAME SRCS ARDLIBS)
                     ${ARDUINO_LIBRARIES_PATH}
                     ${ARDUINO_PLATFORM_LIBRARIES_PATH} ${CMAKE_CURRENT_SOURCE_DIR}
                     ${CMAKE_CURRENT_SOURCE_DIR}/libraries)
-
-                if (EXISTS ${LIB_SEARCH_PATH}/${LIB}/${LIB}.h)
+               
+                _check_path_exists_case_sensitive(exists_case_sensitive 
+                  "${LIB_SEARCH_PATH}/${LIB}/${LIB}.h")
+                if (exists_case_sensitive)
                     list(APPEND ARDUINO_LIBS ${LIB_SEARCH_PATH}/${LIB})
                     break()
                 endif ()
-                if (EXISTS ${LIB_SEARCH_PATH}/${LIB}.h)
+                _check_path_exists_case_sensitive(exists_case_sensitive 
+                  "${LIB_SEARCH_PATH}/${LIB}.h")
+                if (exists_case_sensitive)
                     list(APPEND ARDUINO_LIBS ${LIB_SEARCH_PATH})
                     break()
                 endif ()
 
                 # Some libraries like Wire and SPI require building from source
-                if (EXISTS ${LIB_SEARCH_PATH}/${LIB}/src/${LIB}.h)
+                _check_path_exists_case_sensitive(exists_case_sensitive
+                  "${LIB_SEARCH_PATH}/${LIB}/src/${LIB}.h")
+                if (exists_case_sensitive)
                     message(STATUS "avr library found: ${LIB}")
                     list(APPEND ARDUINO_LIBS ${LIB_SEARCH_PATH}/${LIB}/src)
                     break()
                 endif ()
-                if (EXISTS ${LIB_SEARCH_PATH}/src/${LIB}.h)
+                _check_path_exists_case_sensitive(exists_case_sensitive 
+                  "${LIB_SEARCH_PATH}/src/${LIB}.h")
+                if (exists_case_sensitive)
                     list(APPEND ARDUINO_LIBS ${LIB_SEARCH_PATH}/src)
                     break()
                 endif ()
@@ -78,9 +89,15 @@ function(find_arduino_libraries VAR_NAME SRCS ARDLIBS)
             get_source_file_property(_sketch_generated ${SRC} GENERATED_SKETCH)
 
             if (NOT ${_srcfile_generated} OR ${_sketch_generated})
-                if (NOT (EXISTS ${SRC} OR
-                        EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${SRC} OR
-                        EXISTS ${CMAKE_CURRENT_BINARY_DIR}/${SRC}))
+                _check_path_exists_case_sensitive(exists_case_sensitive_1
+                  "${SRC}")
+                _check_path_exists_case_sensitive(exists_case_sensitive_2
+                  "${CMAKE_CURRENT_SOURCE_DIR}/${SRC}")
+                _check_path_exists_case_sensitive(exists_case_sensitive_3
+                  "${CMAKE_CURRENT_BINARY_DIR}/${SRC}")
+                if (NOT (exists_case_sensitive_1 OR
+                         exists_case_sensitive_2 OR
+                         exists_case_sensitive_3))
                     message(FATAL_ERROR "Invalid source file: ${SRC}")
                 endif ()
                 file(STRINGS ${SRC} SRC_CONTENTS)
@@ -98,13 +115,17 @@ function(find_arduino_libraries VAR_NAME SRCS ARDLIBS)
                                 DIRECTORY     # Property Scope
                                 PROPERTY LINK_DIRECTORIES)
                         foreach (LIB_SEARCH_PATH ${LIBRARY_SEARCH_PATH} ${ARDUINO_LIBRARIES_PATH} ${ARDUINO_PLATFORM_LIBRARIES_PATH} ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/libraries ${ARDUINO_EXTRA_LIBRARIES_PATH})
-                            if (EXISTS ${LIB_SEARCH_PATH}/${INCLUDE_NAME}/${CMAKE_MATCH_1})
+                            _check_path_exists_case_sensitive(exists_case_sensitive
+                              "${LIB_SEARCH_PATH}/${INCLUDE_NAME}/${CMAKE_MATCH_1}")
+                            if (exists_case_sensitive)
                                 list(APPEND ARDUINO_LIBS ${LIB_SEARCH_PATH}/${INCLUDE_NAME})
                                 break()
                             endif ()
 
                             # Some libraries like Wire and SPI require building from source
-                            if (EXISTS ${LIB_SEARCH_PATH}/${INCLUDE_NAME}/src/${CMAKE_MATCH_1})
+                            _check_path_exists_case_sensitive(exists_case_sensitive
+                              "${LIB_SEARCH_PATH}/${INCLUDE_NAME}/src/${CMAKE_MATCH_1}")
+                            if (exists_case_sensitive)
                                 list(APPEND ARDUINO_LIBS ${LIB_SEARCH_PATH}/${INCLUDE_NAME}/src)
                                 break()
                             endif ()

--- a/cmake/Platform/Extras/CheckPathExistsCaseSensitive.cmake
+++ b/cmake/Platform/Extras/CheckPathExistsCaseSensitive.cmake
@@ -1,0 +1,132 @@
+#=============================================================================#
+# _check_path_exists_case_sensitive_brute_force
+# [PRIVATE/INTERNAL]
+#
+# _check_path_exists_case_sensitive_brute_force(result_var_ absolute_path_)
+#
+#        result_var_ - A variable in parent scope that is assigned the result
+#                      of the check. The result is TRUE if the file 
+#                      is found with a case sensitive check, otherwise FALSE.
+#        absolute_path_ 
+#                    - The absoute path of a file or directory.
+#
+# Checks if a path exists in a case sensitive fashion.
+# This is the brute force version of the check that is used when
+# there are no other means available.
+#
+# This is necessary because CMake's if(EXISTS ...) is not case sensitive
+# on Windows (at least not up to CMake version 3.9.6).
+#
+# Important: Do not use this function directly but prefer to use 
+#            _check_path_exists_case_sensitive
+#=============================================================================#
+function(_check_path_exists_case_sensitive_brute_force result_var_ absolute_path_)
+
+   # We recursively traverse the absolute_path_ from its root and
+   # check it any path token cannot be found (early exit)
+
+   string(REPLACE "/" ";" path_tokens "${absolute_path_}") 
+   
+   list(LENGTH path_tokens n_tokens__)
+   math(EXPR n_tokens "${n_tokens__} - 1")
+   
+   set(cur_path "/")
+   foreach(id RANGE 0 ${n_tokens})
+   
+      list(GET path_tokens ${id} cur_token)
+      
+      if("${cur_token}" STREQUAL "")
+         continue()
+      endif()
+   
+      file(GLOB dir_entries RELATIVE "${cur_path}" "${cur_path}*")
+
+      list(FIND dir_entries "${cur_token}" index)
+      if(NOT ${index} GREATER -1)
+         message("- ${absolute_path_}")
+         set(${result_var_} FALSE PARENT_SCOPE)
+         return()
+      endif()
+      
+      set(cur_path "${cur_path}${cur_token}/")
+   endforeach()
+         
+   message("+ ${absolute_path_}")
+   set(${result_var_} TRUE PARENT_SCOPE)
+endfunction()
+   
+#=============================================================================#
+# _check_path_exists_case_sensitive
+# [PRIVATE/INTERNAL]
+#
+# _check_path_exists_case_sensitive(result_var_ absolute_path_)
+#
+#        result_var_ - A variable in parent scope that is assigned the result
+#                      of the check. The result is TRUE if the file 
+#                      is found with a case sensitive check, otherwise FALSE.
+#        absolute_path_ 
+#                    - The absoute path of a file or directory.
+#
+# Checks if a path exists in a case sensitive fashion.
+#
+# This is necessary because CMake's if(EXISTS ...) is not case sensitive
+# on Windows (at least not up to CMake version 3.9.6).
+#=============================================================================#
+function(_check_path_exists_case_sensitive result_var_ absolute_path_)
+   
+   # Important: First check for APPLE as CMAKE_HOST_UNIX reports true even 
+   #            if CMAKE_HOST_APPLE is true
+   #
+   if(CMAKE_HOST_APPLE)
+   
+      # On MacOS there is no appropriate command that enables a safe check
+      # for a path to exist given a case sensitive name. This is because
+      # MacOS file systems are mostly case insensitive by default.
+      # That's why we fall back to brute force directory comparison.
+      #
+      _check_path_exists_case_sensitive_brute_force(tmp_result "${absolute_path_}")
+      set(${result_var_} ${tmp_result} PARENT_SCOPE)
+      
+      return()
+
+   elseif(CMAKE_HOST_UNIX)
+   
+      if(EXISTS "${absolute_path_}")
+         set(${result_var_} TRUE PARENT_SCOPE)
+      else()
+         set(${result_var_} FALSE PARENT_SCOPE)
+      endif()
+      
+      return()
+      
+   elseif(CMAKE_HOST_WIN32)
+   
+      # From this point on, we only deal with Windows
+      
+      file(TO_NATIVE_PATH "${absolute_path_}" native_path)
+      string(REPLACE "/" "\\" native_path "${native_path}")
+      
+      # Check what is found when a globbing expression is used to 
+      # find the file. The output (actual_path) will be the case 
+      # sensitive path name or nothing.
+      #
+      execute_process(
+         ERROR_QUIET
+         OUTPUT_VARIABLE actual_path
+         OUTPUT_STRIP_TRAILING_WHITESPACE
+         COMMAND cmd /C dir /S /B "${native_path}" 
+      )
+
+      if("${actual_path}" STREQUAL "${native_path}")
+         set(${result_var_} TRUE PARENT_SCOPE)
+      else()
+         set(${result_var_} FALSE PARENT_SCOPE)
+      endif()
+      
+      return()
+
+   endif()
+   
+   message(FATAL_ERROR "Strange host system")
+      
+endfunction()


### PR DESCRIPTION
The Arduino build system intents to be user friendly by greatly simplifying the build process.

One feature provided is the automatic generation of a compiler command line. A typical command line consists of definitions of include directories using `-I...`. Include directories that correspond to Arduino libraries are automatically searched for based on the `#include ...` directives found in C/C++ code.

Arduino-CMake implements a search that checks if a library directory for a given header exists. While this works fine with case-sensitive file systems (GNU/Linux) it terribly fails under specific circumstances on MacOS (if the file system is case-insensitive (default)) and Windows. The file systems of both latter platforms are at least case preserving.

The following example demonstrates what can go wrong. Lets assume the following directory structure.
```
.../libraries/A/src/A.cpp
.../libraries/A/src/A.h
.../libraries/A/src/a.h
.../somewhere_else/sketch.ino
```

```cpp
// In sketch.ino
#include "A.h"
```
```cpp
// In A.cpp
#include "a.h"
```

As the sketch includes `A.h`, the library `A` is found and build. Thereby, the header `a.h` is included.
Arduino-CMake will now search for a library `a`. Somewhere in the CMake code there are the line (simplified)

```cmake
if(EXISTS "libraries/a/src")
   # Library 'a' will be considered
  ...
endif
```

On MacOS and Windows, `if(EXISTS ...)` performs a case insensitive lookup. It will thus report library `a` as existent while it actually encounters library `A` in the filesystem. Now, both `a` and `A` will be build, which leads to very strange build errors. The same does not happen on GNU/Linux as there `A` and `a` are different.

I am aware that using headers `a.h` and `A.h` in the same library is not a good idea. But this is a reduced example that demonstrates what can go wrong. The scenario where I stumbled upon this source of error is more complex and both headers reside in different libraries. However, the outcome was the same, the build failed and it took me days to find out what went wrong. 

A portable solution to this problem could be to make `if(EXISTS ...)` case-sensitive. But as this would potentially break other existing CMake projects that potentially rely on case-insensitive `if(EXISTS ...)` and only future versions of CMake could be fixed, a fix to our problem has to be restricted to Arduino-CMake.  

This PR introduces a helper function as a case-sensitive replacement for `if(EXISTS ...)`.