### PR TITLE
Removed unused function parameter SRCS of make_arduino_libraries

### DIFF
--- a/cmake/Platform/Core/Libraries/ArduinoLibraryFactory.cmake
+++ b/cmake/Platform/Core/Libraries/ArduinoLibraryFactory.cmake
@@ -94,14 +94,13 @@ endfunction()
 #
 #        VAR_NAME    - Vairable wich will hold the generated library names
 #        BOARD_ID    - Board ID
-#        SRCS        - source files
 #        COMPILE_FLAGS - Compile flags
 #        LINK_FLAGS    - Linker flags
 #
 # Finds and creates all dependency libraries based on sources.
 #
 #=============================================================================#
-function(make_arduino_libraries VAR_NAME BOARD_ID SRCS ARDLIBS COMPILE_FLAGS LINK_FLAGS)
+function(make_arduino_libraries VAR_NAME BOARD_ID ARDLIBS COMPILE_FLAGS LINK_FLAGS)
     foreach (TARGET_LIB ${ARDLIBS})
         # Create static library instead of returning sources
         make_arduino_library(LIB_DEPS ${BOARD_ID} ${TARGET_LIB}

--- a/cmake/Platform/Generation/ArduinoExampleGenerator.cmake
+++ b/cmake/Platform/Generation/ArduinoExampleGenerator.cmake
@@ -50,7 +50,7 @@ function(GENERATE_ARDUINO_EXAMPLE INPUT_NAME)
         set(LIB_DEP_INCLUDES "${LIB_DEP_INCLUDES} -I\"${LIB_DEP}\"")
     endforeach ()
 
-    make_arduino_libraries(ALL_LIBS ${BOARD_ID} "${ALL_SRCS}" "" "${LIB_DEP_INCLUDES}" "")
+    make_arduino_libraries(ALL_LIBS ${BOARD_ID} "" "${LIB_DEP_INCLUDES}" "")
 
     list(APPEND ALL_LIBS ${CORE_LIB} ${INPUT_LIBS})
 

--- a/cmake/Platform/Generation/ArduinoFirmwareGenerator.cmake
+++ b/cmake/Platform/Generation/ArduinoFirmwareGenerator.cmake
@@ -61,7 +61,7 @@ function(GENERATE_ARDUINO_FIRMWARE INPUT_NAME)
     endforeach ()
 
     if (NOT INPUT_NO_AUTOLIBS)
-        make_arduino_libraries(ALL_LIBS ${BOARD_ID} "${ALL_SRCS}" "${TARGET_LIBS}" "${LIB_DEP_INCLUDES}" "")
+        make_arduino_libraries(ALL_LIBS ${BOARD_ID} "${TARGET_LIBS}" "${LIB_DEP_INCLUDES}" "")
         foreach (LIB_INCLUDES ${ALL_LIBS_INCLUDES})
             arduino_debug_msg("Arduino Library Includes: ${LIB_INCLUDES}")
             set(LIB_DEP_INCLUDES "${LIB_DEP_INCLUDES} ${LIB_INCLUDES}")

--- a/cmake/Platform/Generation/ArduinoLibraryExampleGenerator.cmake
+++ b/cmake/Platform/Generation/ArduinoLibraryExampleGenerator.cmake
@@ -49,7 +49,7 @@ function(GENERATE_ARDUINO_LIBRARY_EXAMPLE INPUT_NAME)
         message(FATAL_ERROR "Missing sources for example, aborting!")
     endif ()
 
-    make_arduino_libraries(ALL_LIBS ${BOARD_ID} "${ALL_SRCS}" "${TARGET_LIBS}"
+    make_arduino_libraries(ALL_LIBS ${BOARD_ID} "${TARGET_LIBS}"
             "${LIB_DEP_INCLUDES}" "")
 
     list(APPEND ALL_LIBS ${CORE_LIB} ${INPUT_LIBS})

--- a/cmake/Platform/Generation/ArduinoLibraryGenerator.cmake
+++ b/cmake/Platform/Generation/ArduinoLibraryGenerator.cmake
@@ -38,7 +38,7 @@ function(GENERATE_ARDUINO_LIBRARY INPUT_NAME)
     endforeach ()
 
     if (NOT ${INPUT_NO_AUTOLIBS})
-        make_arduino_libraries(ALL_LIBS ${BOARD_ID} "${ALL_SRCS}" "" "${LIB_DEP_INCLUDES}" "")
+        make_arduino_libraries(ALL_LIBS ${BOARD_ID} "" "${LIB_DEP_INCLUDES}" "")
     endif ()
 
     list(APPEND ALL_LIBS ${CORE_LIB} ${INPUT_LIBS})


### PR DESCRIPTION
The parameter `SRCS` is unused in function `make_arduino_libraries`. 
When trying to understand the logic of establishing build targets, passing unused parameters is distracting. This PR removes the parameter and corrects all uses of the function.