### PR TITLE
Separated source and header file search

### DIFF
--- a/cmake/Platform/Core/Libraries/ArduinoLibraryFactory.cmake
+++ b/cmake/Platform/Core/Libraries/ArduinoLibraryFactory.cmake
@@ -31,6 +31,10 @@ function(make_arduino_library VAR_NAME BOARD_ID LIB_PATH COMPILE_FLAGS LINK_FLAG
         endif ()
 
         find_sources(LIB_SRCS ${LIB_PATH} ${${LIB_SHORT_NAME}_RECURSE})
+        find_headers(LIB_HDRS ${LIB_PATH} ${${LIB_SHORT_NAME}_RECURSE})
+        
+        # Only build the library if there are source files
+        #
         if (LIB_SRCS)
 
             arduino_debug_msg("Generating Arduino ${LIB_NAME} library")
@@ -38,7 +42,9 @@ function(make_arduino_library VAR_NAME BOARD_ID LIB_PATH COMPILE_FLAGS LINK_FLAG
 
             set_board_flags(ARDUINO_COMPILE_FLAGS ARDUINO_LINK_FLAGS ${BOARD_ID} FALSE)
 
-            find_arduino_libraries(LIB_DEPS "${LIB_SRCS}" "")
+            # Find libraries that contain related sources and headers
+            #
+            find_arduino_libraries(LIB_DEPS "${LIB_SRCS};${LIB_HDRS}" "")
 
             foreach (LIB_DEP ${LIB_DEPS})
                 make_arduino_library(DEP_LIB_SRCS ${BOARD_ID} ${LIB_DEP}

--- a/cmake/Platform/Core/Libraries/ArduinoLibraryFactory.cmake
+++ b/cmake/Platform/Core/Libraries/ArduinoLibraryFactory.cmake
@@ -29,6 +29,12 @@ function(make_arduino_library VAR_NAME BOARD_ID LIB_PATH COMPILE_FLAGS LINK_FLAG
         if (NOT DEFINED ${LIB_SHORT_NAME}_RECURSE)
             set(${LIB_SHORT_NAME}_RECURSE ${ARDUINO_CMAKE_RECURSION_DEFAULT})
         endif ()
+        
+        # As this function is used recursively, it is important to 
+        # clear the following variables that are potentially existent in parent scope
+        #
+        set(LIB_SRCS)
+        set(LIB_HDRS)
 
         find_sources(LIB_SRCS ${LIB_PATH} ${${LIB_SHORT_NAME}_RECURSE})
         find_headers(LIB_HDRS ${LIB_PATH} ${${LIB_SHORT_NAME}_RECURSE})

--- a/cmake/Platform/Core/SourceFinder.cmake
+++ b/cmake/Platform/Core/SourceFinder.cmake
@@ -17,9 +17,6 @@ function(find_sources VAR_NAME LIB_PATH RECURSE)
             ${LIB_PATH}/*.c
             ${LIB_PATH}/*.cc
             ${LIB_PATH}/*.cxx
-            ${LIB_PATH}/*.h
-            ${LIB_PATH}/*.hh
-            ${LIB_PATH}/*.hxx
             ${LIB_PATH}/*.[sS]
             )
 
@@ -31,6 +28,37 @@ function(find_sources VAR_NAME LIB_PATH RECURSE)
 
     if (SOURCE_FILES)
         set(${VAR_NAME} ${SOURCE_FILES} PARENT_SCOPE)
+    endif ()
+endfunction()
+
+#=============================================================================#
+# find_headers
+# [PRIVATE/INTERNAL]
+#
+# find_headers(VAR_NAME LIB_PATH RECURSE)
+#
+#        VAR_NAME - Variable name that will hold the detected headers
+#        LIB_PATH - The base path
+#        RECURSE  - Whether or not to recurse
+#
+# Finds all C/C++ headers located at the specified path.
+#
+#=============================================================================#
+function(find_headers VAR_NAME LIB_PATH RECURSE)
+    set(FILE_SEARCH_LIST
+            ${LIB_PATH}/*.h
+            ${LIB_PATH}/*.hh
+            ${LIB_PATH}/*.hxx
+            )
+
+    if (RECURSE)
+        file(GLOB_RECURSE HEADER_FILES ${FILE_SEARCH_LIST})
+    else ()
+        file(GLOB HEADER_FILES ${FILE_SEARCH_LIST})
+    endif ()
+
+    if (HEADER_FILES)
+        set(${VAR_NAME} ${HEADER_FILES} PARENT_SCOPE)
     endif ()
 endfunction()
 


### PR DESCRIPTION
Arduino-CMake tries to build Arduino libraries that contain only headers but no sources. This leads to configuration errors. By splitting up the search for sources and headers, this can be prevented.

This PR splits up the source detection in source and header detection and fixes any use of the pre-existent function `find_sources` that requires changes.