### PR TITLE
Removed build of libraries that do not contain sources

### DIFF
--- a/cmake/Platform/Core/Libraries/ArduinoLibraryFactory.cmake
+++ b/cmake/Platform/Core/Libraries/ArduinoLibraryFactory.cmake
@@ -22,23 +22,32 @@ function(make_arduino_library VAR_NAME BOARD_ID LIB_PATH COMPILE_FLAGS LINK_FLAG
     get_filename_component(LIB_NAME ${LIB_PATH_STRIPPED} NAME)
     set(TARGET_LIB_NAME ${BOARD_ID}_${LIB_NAME})
 
-    if (NOT TARGET ${TARGET_LIB_NAME})
-        string(REGEX REPLACE ".*/" "" LIB_SHORT_NAME ${LIB_NAME})
+    string(REGEX REPLACE ".*/" "" LIB_SHORT_NAME ${LIB_NAME})
 
-        # Detect if recursion is needed
-        if (NOT DEFINED ${LIB_SHORT_NAME}_RECURSE)
-            set(${LIB_SHORT_NAME}_RECURSE ${ARDUINO_CMAKE_RECURSION_DEFAULT})
-        endif ()
+    # Detect if recursion is needed
+    if (NOT DEFINED ${LIB_SHORT_NAME}_RECURSE)
+       set(${LIB_SHORT_NAME}_RECURSE ${ARDUINO_CMAKE_RECURSION_DEFAULT})
+    endif ()
 
-        find_sources(LIB_SRCS ${LIB_PATH} ${${LIB_SHORT_NAME}_RECURSE})
-        if (LIB_SRCS)
+    # As make_arduino_library is called recursively, LIB_SRCS and LIB_HDRS
+    # might be defined in parent scope and must therefore be cleared.
+    #
+    set(LIB_SRCS)
+    set(LIB_HDRS)
+    
+    find_sources(LIB_SRCS ${LIB_PATH} ${${LIB_SHORT_NAME}_RECURSE})
+    find_headers(LIB_HDRS ${LIB_PATH} ${${LIB_SHORT_NAME}_RECURSE})
+    
+    if (LIB_SRCS)
+        
+       if (NOT TARGET ${TARGET_LIB_NAME})
 
             arduino_debug_msg("Generating Arduino ${LIB_NAME} library")
             add_library(${TARGET_LIB_NAME} STATIC ${LIB_SRCS})
 
             set_board_flags(ARDUINO_COMPILE_FLAGS ARDUINO_LINK_FLAGS ${BOARD_ID} FALSE)
 
-            find_arduino_libraries(LIB_DEPS "${LIB_SRCS}" "")
+            find_arduino_libraries(LIB_DEPS "${LIB_SRCS};${LIB_HDRS}" "")
 
             foreach (LIB_DEP ${LIB_DEPS})
                 make_arduino_library(DEP_LIB_SRCS ${BOARD_ID} ${LIB_DEP}
@@ -63,14 +72,15 @@ function(make_arduino_library VAR_NAME BOARD_ID LIB_PATH COMPILE_FLAGS LINK_FLAG
             if(NOT ARDUINO_CMAKE_GENERATE_SHARED_LIBRARIES)
                 target_link_libraries(${TARGET_LIB_NAME} ${BOARD_ID}_CORE ${LIB_TARGETS})
             endif()
-            
-            list(APPEND LIB_TARGETS ${TARGET_LIB_NAME})
 
         endif ()
+           
+        list(APPEND LIB_TARGETS ${TARGET_LIB_NAME})
 
     else ()
-        # Target already exists, skiping creating
-        list(APPEND LIB_TARGETS ${TARGET_LIB_NAME})
+        # Target not build due to lack of sources. However, the library might contain
+        # headers.
+        #
         list(APPEND LIB_INCLUDES "-I\"${LIB_PATH}\"")
     endif ()
 

--- a/cmake/Platform/Core/SourceFinder.cmake
+++ b/cmake/Platform/Core/SourceFinder.cmake
@@ -17,9 +17,6 @@ function(find_sources VAR_NAME LIB_PATH RECURSE)
             ${LIB_PATH}/*.c
             ${LIB_PATH}/*.cc
             ${LIB_PATH}/*.cxx
-            ${LIB_PATH}/*.h
-            ${LIB_PATH}/*.hh
-            ${LIB_PATH}/*.hxx
             ${LIB_PATH}/*.[sS]
             )
 
@@ -31,6 +28,37 @@ function(find_sources VAR_NAME LIB_PATH RECURSE)
 
     if (SOURCE_FILES)
         set(${VAR_NAME} ${SOURCE_FILES} PARENT_SCOPE)
+    endif ()
+endfunction()
+
+#=============================================================================#
+# find_headers
+# [PRIVATE/INTERNAL]
+#
+# find_headers(VAR_NAME LIB_PATH RECURSE)
+#
+#        VAR_NAME - Variable name that will hold the detected headers
+#        LIB_PATH - The base path
+#        RECURSE  - Whether or not to recurse
+#
+# Finds all C/C++ headers located at the specified path.
+#
+#=============================================================================#
+function(find_headers VAR_NAME LIB_PATH RECURSE)
+    set(FILE_SEARCH_LIST
+            ${LIB_PATH}/*.h
+            ${LIB_PATH}/*.hh
+            ${LIB_PATH}/*.hxx
+            )
+
+    if (RECURSE)
+        file(GLOB_RECURSE HEADER_FILES ${FILE_SEARCH_LIST})
+    else ()
+        file(GLOB HEADER_FILES ${FILE_SEARCH_LIST})
+    endif ()
+
+    if (HEADER_FILES)
+        set(${VAR_NAME} ${HEADER_FILES} PARENT_SCOPE)
     endif ()
 endfunction()
 


### PR DESCRIPTION
Arduino-CMake tries to build Arduino libraries that contain only headers but no sources. This leads to configuration errors. By splitting up the search for sources and headers, this can be prevented.

This PR splits up the source detection in source and header detection and fixes any use of the pre-existent function find_sources that requires changes. It also takes care that only those libraries are actually build that contain source files (not header files).