### PR TITLE
[arduino-cmake] The ARDUINO_C_FLAGS is set inside a function and the …

### DIFF
--- a/cmake/Platform/Initialization/SetupCompilerSettings.cmake
+++ b/cmake/Platform/Initialization/SetupCompilerSettings.cmake
@@ -11,7 +11,7 @@
 #=============================================================================#
 function(setup_c_flags)
     if (NOT DEFINED ARDUINO_C_FLAGS)
-        set(ARDUINO_C_FLAGS "-mcall-prologues -ffunction-sections -fdata-sections"  CACHE INTERNAL "")
+        set(ARDUINO_C_FLAGS "-mcall-prologues -ffunction-sections -fdata-sections"  CACHE INTERNAL "") 
     endif (NOT DEFINED ARDUINO_C_FLAGS)
     set(CMAKE_C_FLAGS "-g -Os       ${ARDUINO_C_FLAGS}" CACHE STRING "")
     set(CMAKE_C_FLAGS_DEBUG "-g           ${ARDUINO_C_FLAGS}" CACHE STRING "")

--- a/cmake/Platform/Initialization/SetupCompilerSettings.cmake
+++ b/cmake/Platform/Initialization/SetupCompilerSettings.cmake
@@ -11,7 +11,7 @@
 #=============================================================================#
 function(setup_c_flags)
     if (NOT DEFINED ARDUINO_C_FLAGS)
-        set(ARDUINO_C_FLAGS "-mcall-prologues -ffunction-sections -fdata-sections")
+        set(ARDUINO_C_FLAGS "-mcall-prologues -ffunction-sections -fdata-sections"  CACHE INTERNAL "")
     endif (NOT DEFINED ARDUINO_C_FLAGS)
     set(CMAKE_C_FLAGS "-g -Os       ${ARDUINO_C_FLAGS}" CACHE STRING "")
     set(CMAKE_C_FLAGS_DEBUG "-g           ${ARDUINO_C_FLAGS}" CACHE STRING "")

--- a/cmake/Platform/Initialization/SetupCompilerSettings.cmake
+++ b/cmake/Platform/Initialization/SetupCompilerSettings.cmake
@@ -33,7 +33,7 @@ endfunction()
 #=============================================================================#
 function(setup_cxx_flags)
     if (NOT DEFINED ARDUINO_CXX_FLAGS)
-        set(ARDUINO_CXX_FLAGS "${ARDUINO_C_FLAGS} -fno-exceptions")
+        set(ARDUINO_CXX_FLAGS "${ARDUINO_C_FLAGS} -fno-exceptions" CACHE INTERNAL "")
     endif (NOT DEFINED ARDUINO_CXX_FLAGS)
     set(CMAKE_CXX_FLAGS "-g -Os       ${ARDUINO_CXX_FLAGS}" CACHE STRING "")
     set(CMAKE_CXX_FLAGS_DEBUG "-g           ${ARDUINO_CXX_FLAGS}" CACHE STRING "")


### PR DESCRIPTION
ARDUINO_C_FLAGS is changed inside a function so the change is lost upon exiting. The problem is that it is reused later on when setting the ARDUINO_CXX_FLAGS. The effect is we lose -mcall-prologues -ffunction-sections -fdata-sections for C++ files,  so the final size is 10% bigger. 
Quick and dirty fix : Mark it as cache internal so the change sticks