### PR TITLE
add discovered arduino library dependencies as link targets to genera…

### DIFF
--- a/cmake/Platform/Generation/ArduinoLibraryGenerator.cmake
+++ b/cmake/Platform/Generation/ArduinoLibraryGenerator.cmake
@@ -35,7 +35,7 @@ function(GENERATE_ARDUINO_LIBRARY INPUT_NAME)
     endforeach ()
 
     if (NOT ${INPUT_NO_AUTOLIBS})
-        make_arduino_libraries(ALL_LIBS ${BOARD_ID} "${ALL_SRCS}" "" "${LIB_DEP_INCLUDES}" "")
+        make_arduino_libraries(ALL_LIBS ${BOARD_ID} "${ALL_SRCS}" "${TARGET_LIBS}" "${LIB_DEP_INCLUDES}" "")
     endif ()
 
     list(APPEND ALL_LIBS ${CORE_LIB} ${INPUT_LIBS})


### PR DESCRIPTION
…ted arduino libraries.

I was building a project involving compiling RadioHead which uses the arduino SPI library. I compiled it as a static library first. It compiled fine but linking failed with unresolved references. Simply swapping the ordering of the SPI static library file allowed it to compile.

Looking into the code, the dependency on uno_SPI library wasn't being set without this change.

Maybe I'm using it wrong though,